### PR TITLE
Feat/unbind exception

### DIFF
--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -209,3 +209,22 @@ class TestEvents:
         event.unbind(widget, func_id)
 
         assert func_id not in event.get_bindings(widget)
+
+    def test_unbind_raises_keyerror_for_nonexistent_funcid(self, widget):
+        """Test that unbind raises a KeyError when trying to unbind a non-existent
+        funcid."""
+        event = TkEvent.BUTTON + "<1>"
+        nonexistent_funcid = "nonexistent123"
+
+        with pytest.raises(KeyError):
+            event.unbind(widget, nonexistent_funcid)
+
+    def test_unbind_keyerror_message_contains_funcid(self, widget):
+        """Test that the KeyError message contains the funcid that was not found."""
+        event = TkEvent.BUTTON + "<1>"
+        nonexistent_funcid = "nonexistent123"
+
+        with pytest.raises(
+            KeyError, match=r"Function ID 'nonexistent123' not found in bindings"
+        ):
+            event.unbind(widget, nonexistent_funcid)

--- a/tklife/event.py
+++ b/tklife/event.py
@@ -109,6 +109,9 @@ class BaseEvent:
             funcid: The callback id to remove, or None for all (default: None)
             classname: The classname to unbind on, or None for widget
 
+        Raises:
+            KeyError: If the provided funcid is not found in the current bindings
+
         """
         if not funcid:
             widget.tk.call("bind", classname or str(widget), self.value, "")

--- a/tklife/event.py
+++ b/tklife/event.py
@@ -114,6 +114,8 @@ class BaseEvent:
             widget.tk.call("bind", classname or str(widget), self.value, "")
             return
         func_callbacks = self.get_bindings(widget, classname=classname)
+        if funcid not in func_callbacks:
+            raise KeyError(f"Function ID '{funcid}' not found in bindings")
         new_callbacks = [v for k, v in func_callbacks.items() if k != funcid]
         widget.tk.call(
             "bind", classname or str(widget), self.value, "\n".join(new_callbacks)


### PR DESCRIPTION
This pull request introduces enhancements to error handling and testing in the `unbind` functionality for event bindings. The changes ensure that attempting to unbind a non-existent function ID raises a `KeyError` with a clear and informative message, and corresponding tests are added to verify this behavior.

### Error handling improvements:

* [`tklife/event.py`](diffhunk://#diff-87c635f966073a8955b65d92ffeca382d75da642679525765a1c70bb726849d9R112-R121): Updated the `unbind` method to raise a `KeyError` if the provided `funcid` is not found in the current bindings, with a descriptive error message.

### Testing enhancements:

* `tests/test_event.py`: Added two new test cases:
  - [`test_unbind_raises_keyerror_for_nonexistent_funcid`](diffhunk://#diff-97705a5cb9bfe4fc2cccba14e2775d10b440fd2c837dd2a808ab8fcc8f2e7938R212-R230): Verifies that a `KeyError` is raised when attempting to unbind a non-existent function ID.
  - [`test_unbind_keyerror_message_contains_funcid`](diffhunk://#diff-97705a5cb9bfe4fc2cccba14e2775d10b440fd2c837dd2a808ab8fcc8f2e7938R212-R230): Ensures the `KeyError` message includes the missing `funcid` for clarity.

### Issues

- Fixes #10 