### PR TITLE
Feature/skeleton mixin subclassing

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -167,6 +167,7 @@ class TestSkeletonMixin:
         "mixin_class",
         [
             SkeletonMixin,
+            type("SkeletonMixinSubclass", (SkeletonMixin,), {}),
         ],
     )
     def test_meta_dunder_new_typechecks_bases(self, mock_mixin_class, mixin_class):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -174,6 +174,14 @@ class TestSkeletonMixin:
                 def template(self):
                     return [[]]
 
+    def test_meta_dunder_new_does_not_raise_error_with_SkeletonMixin_subclass_as_first_base(
+        self, mock_mixin_class
+    ):
+        class _TestedSkeleton(
+            type("SkeletonMixinSubclass", (SkeletonMixin,), {}), mock_mixin_class
+        ):
+            pass
+
     def test_controller_attrgetter_returns_proxy_factory_if_controller_not_set(
         self, no_template_skeleton, mock_master
     ):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -163,16 +163,21 @@ class TestSkeletonMixin:
             call()._create_events(),
         ]
 
-    def test_meta_dunder_new_typechecks_bases(self, mock_mixin_class):
-        with pytest.raises(
-            TypeError,
-            match=r"\<class 'tklife\.core\.SkeletonMixin'\> should be first base class",
-        ):
+    @pytest.mark.parametrize(
+        "mixin_class",
+        [
+            SkeletonMixin,
+        ],
+    )
+    def test_meta_dunder_new_typechecks_bases(self, mock_mixin_class, mixin_class):
+        with pytest.raises(TypeError) as exc:
 
-            class _TestedSkeleton(mock_mixin_class, SkeletonMixin):
+            class _TestedSkeleton(mock_mixin_class, mixin_class):
                 @property
                 def template(self):
                     return [[]]
+
+        assert str(exc.value) == f"{mixin_class} should be first base class"
 
     def test_meta_dunder_new_does_not_raise_error_with_SkeletonMixin_subclass_as_first_base(
         self, mock_mixin_class
@@ -879,4 +884,6 @@ class TestCreatedWidget:
 
     def test_dunder_setitem_raises_attribute_error(self, created_widget):
         with pytest.raises(AttributeError):
+            created_widget["not_an_attribute"] = "value"
+            created_widget["not_an_attribute"] = "value"
             created_widget["not_an_attribute"] = "value"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -886,5 +886,3 @@ class TestCreatedWidget:
     def test_dunder_setitem_raises_attribute_error(self, created_widget):
         with pytest.raises(AttributeError):
             created_widget["not_an_attribute"] = "value"
-            created_widget["not_an_attribute"] = "value"
-            created_widget["not_an_attribute"] = "value"

--- a/tklife/core.py
+++ b/tklife/core.py
@@ -363,8 +363,13 @@ class CachedWidget(NamedTuple):
 
 class _SkeletonMeta(type):
     def __new__(mcs, name, bases: tuple[type, ...], namespace):
-        if Generic not in bases and len(bases) > 1 and bases[0] != SkeletonMixin:
-            raise TypeError(f"{SkeletonMixin} should be first base class")
+        if (
+            Generic not in bases
+            and len(bases) > 1
+            and not issubclass(bases[0], SkeletonMixin)
+        ):
+            mixin = next(b for b in bases if issubclass(b, SkeletonMixin))
+            raise TypeError(f"{mixin} should be first base class")
         return super().__new__(mcs, name, bases, namespace)
 
 


### PR DESCRIPTION
This pull request refines type-checking logic for base classes in the `tklife.core.SkeletonMixin` and improves test coverage to account for edge cases involving subclasses of `SkeletonMixin`. The main changes include updates to the `_SkeletonMeta` class and related tests.

### Updates to type-checking logic:

* [`tklife/core.py`](diffhunk://#diff-2e24cf3686cad235a77b51c9bbfbebed113ff804ad1a3e561b0d2a76c4104381L366-R372): Modified `_SkeletonMeta.__new__` to allow subclasses of `SkeletonMixin` as valid first base classes and improved error messages by referencing the specific invalid base class.

### Improvements to test coverage:

* [`tests/test_core.py`](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058L166-R190): Updated `test_meta_dunder_new_typechecks_bases` to use parameterized tests for validating both `SkeletonMixin` and its subclasses. Added a new test, `test_meta_dunder_new_does_not_raise_error_with_SkeletonMixin_subclass_as_first_base`, to ensure subclasses of `SkeletonMixin` are handled correctly.

### Issues

- Closes #20 