### PR TITLE
Refactor/copy geometry methods

### DIFF
--- a/tklife/widgets.py
+++ b/tklife/widgets.py
@@ -163,15 +163,7 @@ class ScrolledFrame(ttk.Frame):
         self.__layout()
         self.__commands()
         self.__events()
-        # Copy geometry methods of self.container without overriding Frame
-        # methods -- hack!
-        text_meths = vars(ttk.Frame).keys()
-        methods = vars(tk.Pack).keys() | vars(tk.Grid).keys() | vars(tk.Place).keys()
-        methods = methods.difference(text_meths)
-
-        for m in methods:
-            if m[0] != "_" and m != "config" and m != "configure":
-                setattr(self, m, getattr(self.container, m))
+        copy_geometry_methods(self.container, self)
 
     def __layout(self):
         self.canvas.grid(column=0, row=0, sticky=tk.NW + tk.SE)

--- a/tklife/widgets.py
+++ b/tklife/widgets.py
@@ -23,6 +23,19 @@ __all__ = ["ScrolledListbox", "AutoSearchCombobox", "ScrolledFrame", "ModalDialo
 T_ReturnValue = typing.TypeVar("T_ReturnValue")  # pylint: disable=invalid-name
 
 
+def copy_geometry_methods(
+    source: Misc, target: Misc
+) -> None:
+    """Copies the geometry methods from source to target without overriding the target's
+    methods, like in ``tkinter.scrolledtext.ScrolledText``."""
+    text_meths = vars(type(source)).keys()
+    methods = vars(tk.Pack).keys() | vars(tk.Grid).keys() | vars(tk.Place).keys()
+    methods = methods.difference(text_meths)
+    for method in methods:
+        if method[0] != "_" and method != "config" and method != "configure":
+            setattr(target, method, getattr(source, method))
+
+
 class ModalDialog(
     tkl.core.SkeletonMixin[T_Controller],
     typing.Generic[T_ReturnValue, T_Controller],

--- a/tklife/widgets.py
+++ b/tklife/widgets.py
@@ -281,15 +281,7 @@ class ScrolledListbox(tk.Listbox):
         self.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.vbar["command"] = self.yview
 
-        # Copy geometry methods of self.frame without overriding Listbox
-        # methods -- hack!
-        text_meths = vars(tk.Listbox).keys()
-        methods = vars(tk.Pack).keys() | vars(tk.Grid).keys() | vars(tk.Place).keys()
-        methods = methods.difference(text_meths)
-
-        for m in methods:
-            if m[0] != "_" and m != "config" and m != "configure":
-                setattr(self, m, getattr(self.frame, m))
+        copy_geometry_methods(self.frame, self)
 
     def __str__(self):
         return str(self.frame)


### PR DESCRIPTION
This pull request refactors the codebase by introducing a reusable utility function, `copy_geometry_methods`, to streamline the copying of geometry methods between objects. This change eliminates duplicate code and improves maintainability.

### Refactoring for Reusability:

* [`tklife/widgets.py`](diffhunk://#diff-ef50cda4b52df652ddff0ef109ce94ec20c832b6f08b0bb534f00efba371dfd1R26-R38): Added a new function `copy_geometry_methods` to copy geometry methods from a source object to a target object without overriding existing methods. This function centralizes the logic for copying methods, making it reusable across different parts of the codebase.
* [`tklife/widgets.py`](diffhunk://#diff-ef50cda4b52df652ddff0ef109ce94ec20c832b6f08b0bb534f00efba371dfd1L153-R166): Updated the `__init__` method of two classes to replace the inline logic for copying geometry methods with a call to the new `copy_geometry_methods` function. This change removes duplicated code and ensures consistency. [[1]](diffhunk://#diff-ef50cda4b52df652ddff0ef109ce94ec20c832b6f08b0bb534f00efba371dfd1L153-R166) [[2]](diffhunk://#diff-ef50cda4b52df652ddff0ef109ce94ec20c832b6f08b0bb534f00efba371dfd1L279-R284)